### PR TITLE
open WsConfigurator

### DIFF
--- a/kotlin/yass-transport-ws/main/ch/softappeal/yass/transport/ws/WsTransport.kt
+++ b/kotlin/yass-transport-ws/main/ch/softappeal/yass/transport/ws/WsTransport.kt
@@ -84,13 +84,13 @@ fun asyncWsConnectionFactory(sendTimeoutMilliSeconds: Long): WsConnectionFactory
     }
 }
 
-class WsConfigurator(
+open class WsConfigurator(
     private val connectionFactory: WsConnectionFactory, private val transport: SessionTransport
 ) : ServerEndpointConfig.Configurator() {
     val endpointInstance: Endpoint = getEndpointInstance(Endpoint::class.java)
 
     @Suppress("UNCHECKED_CAST")
-    override fun <T> getEndpointInstance(endpointClass: Class<T>): T = object : Endpoint() {
+    final override fun <T> getEndpointInstance(endpointClass: Class<T>): T = object : Endpoint() {
         @Volatile
         private var connection: WsConnection? = null
 


### PR DESCRIPTION
I need to have the possibility to overwrite the modifyHandshake function, because I want add a property from the HttpSession into the WebSocketSession.
Here is my overwritten modifyHandshake function:
```
override fun modifyHandshake(sec: ServerEndpointConfig?, request: HandshakeRequest?, response: HandshakeResponse?) {
    sec!!.userProperties["REQUEST_CONTEXT"] = (request!!.httpSession as HttpSession).getAttribute("REQUEST_CONTEXT")
}
```

later in my BrowerSession I read this property from the WebsocketSession:



```
@Override protected void opened()
    this.requestContext = (RequestContext) ((WsConnection)this.getConnection()).getSession().getUserProperties().get("REQUEST_CONTEXT");
    LOGGER.info("Session {} created for {}", this, requestContext.userId);
    LOGGER.info("Session {} opened", this);
}
```


At the moment I just created my own WsConfigurator as a workaround.
Cheers, Philipp